### PR TITLE
allow `None` for the `.dbc` attributes of message and database objects

### DIFF
--- a/src/cantools/database/can/database.py
+++ b/src/cantools/database/can/database.py
@@ -60,7 +60,7 @@ class Database:
         self._name_to_message: dict[str, Message] = {}
         self._frame_id_to_message: dict[int, Message] = {}
         self._version = version
-        self._dbc = dbc_specifics or DbcSpecifics()
+        self._dbc = dbc_specifics
         self._autosar = autosar_specifics
 
         if frame_id_mask is None:
@@ -112,7 +112,7 @@ class Database:
         self._version = value
 
     @property
-    def dbc(self) -> DbcSpecifics:
+    def dbc(self) -> DbcSpecifics | None:
         """An object containing dbc specific properties like e.g. attributes.
 
         """
@@ -120,7 +120,7 @@ class Database:
         return self._dbc
 
     @dbc.setter
-    def dbc(self, value: DbcSpecifics) -> None:
+    def dbc(self, value: DbcSpecifics | None) -> None:
         self._dbc = value
 
     @property

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -499,12 +499,13 @@ def _dump_nodes(database: InternalDatabase) -> list[str]:
 def _dump_value_tables(database: InternalDatabase) -> list[str]:
     val_table: list[str] = []
 
-    for name, choices in database.dbc.value_tables.items():
-        choices_list = [
-            f'{number} "{text}"'
-            for number, text in sorted(choices.items(), reverse=True)
-        ]
-        val_table.append('VAL_TABLE_ {} {} ;'.format(name, ' '.join(choices_list)))
+    if database.dbc is not None:
+        for name, choices in database.dbc.value_tables.items():
+            choices_list = [
+                f'{number} "{text}"'
+                for number, text in sorted(choices.items(), reverse=True)
+            ]
+            val_table.append('VAL_TABLE_ {} {} ;'.format(name, ' '.join(choices_list)))
 
     return [*val_table, '']
 
@@ -646,14 +647,19 @@ def _need_cycletime_def(database: InternalDatabase) -> bool:
                for m in database.messages)
 
 def _bus_is_canfd(database: InternalDatabase) -> bool:
+    if database.dbc is None:
+        return False
+
     bus_type = database.dbc.attributes.get('BusType', None)
     if bus_type is None:
         return False
     return bus_type.value == 'CAN FD'
 
 def _dump_attribute_definitions(database: InternalDatabase) -> list[str]:
-    ba_def: list[str] = []
+    if database.dbc is None:
+        return  []
 
+    ba_def: list[str] = []
     definitions = database.dbc.attribute_definitions
 
     # define "GenMsgCycleTime" attribute for specifying the cycle
@@ -690,8 +696,10 @@ def _dump_attribute_definitions(database: InternalDatabase) -> list[str]:
 
 
 def _dump_attribute_definitions_rel(database: InternalDatabase) -> list[str]:
-    ba_def_rel: list[str] = []
+    if database.dbc is None:
+        return  []
 
+    ba_def_rel: list[str] = []
     definitions = database.dbc.attribute_definitions_rel
 
     for definition in definitions.values():
@@ -711,8 +719,10 @@ def _dump_attribute_definitions_rel(database: InternalDatabase) -> list[str]:
 
 
 def _dump_attribute_definition_defaults(database: InternalDatabase) -> list[str]:
-    ba_def_def: list[str] = []
+    if database.dbc is None:
+        return  []
 
+    ba_def_def: list[str] = []
     definitions = database.dbc.attribute_definitions
 
     for definition in definitions.values():
@@ -729,8 +739,10 @@ def _dump_attribute_definition_defaults(database: InternalDatabase) -> list[str]
 
 
 def _dump_attribute_definition_defaults_rel(database: InternalDatabase) -> list[str]:
-    ba_def_def_rel: list[str] = []
+    if database.dbc is None:
+        return  []
 
+    ba_def_def_rel: list[str] = []
     definitions = database.dbc.attribute_definitions_rel
 
     for definition in definitions.values():
@@ -747,6 +759,9 @@ def _dump_attribute_definition_defaults_rel(database: InternalDatabase) -> list[
 
 
 def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals, sort_attributes: type_sort_attributes) -> list[str]:
+    if database.dbc is None:
+        return  []
+
     attributes: list[type_sort_attribute] = []
 
     for attribute in database.dbc.attributes.values():
@@ -761,27 +776,31 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
             attributes.append(('node', attribute, node, None, None, None))
 
     for message in database.messages:
-        # retrieve the ordered dictionary of message attributes
-        msg_attributes = message.dbc.attributes
+        msg_attributes = OrderedDict[str, AttributeType]()
+        if message.dbc is not None:
+            msg_attributes = deepcopy(message.dbc.attributes)
 
         # synchronize the attribute for the message cycle time with
         # the cycle time specified by the message object
-        gen_msg_cycle_time_def: AttributeDefinition[int] | None
         msg_cycle_time = message.cycle_time or 0
-        if gen_msg_cycle_time_def := typing.cast("AttributeDefinition[int] | None", database.dbc.attribute_definitions.get("GenMsgCycleTime")):
-            if msg_cycle_time != gen_msg_cycle_time_def.default_value:
-                msg_attributes['GenMsgCycleTime'] = Attribute(
-                    value=msg_cycle_time,
-                    definition=gen_msg_cycle_time_def,
-                )
-            elif 'GenMsgCycleTime' in msg_attributes:
-                del msg_attributes['GenMsgCycleTime']
+
+        gen_msg_cycle_time_def = None
+        if message.dbc is not None:
+            gen_msg_cycle_time_def = database.dbc.attribute_definitions.get("GenMsgCycleTime")
+
+        if gen_msg_cycle_time_def is not None and msg_cycle_time != gen_msg_cycle_time_def.default_value:
+            msg_attributes['GenMsgCycleTime'] = Attribute(
+                value=msg_cycle_time,
+                definition=typing.cast('AttributeDefinition[int]', gen_msg_cycle_time_def),
+            )
         elif 'GenMsgCycleTime' in msg_attributes:
             del msg_attributes['GenMsgCycleTime']
 
         # if bus is CAN FD, set VFrameFormat
-        v_frame_format_def: AttributeDefinitionType | None
-        if v_frame_format_def := database.dbc.attribute_definitions.get("VFrameFormat"):
+        v_frame_format_def = None
+        if database.dbc is not None:
+            v_frame_format_def = database.dbc.attribute_definitions.get("VFrameFormat")
+        if v_frame_format_def is not None:
             if message.protocol == 'j1939':
                 v_frame_format_str = 'J1939PG'
             elif message.is_fd and message.is_extended_frame:
@@ -869,8 +888,10 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
 
 
 def _dump_attributes_rel(database: InternalDatabase, sort_signals: type_sort_signals) -> str | list[str]:
-    ba_rel: list[str] = []
+    if database.dbc is None:
+        return  []
 
+    ba_rel: list[str] = []
     attributes_rel = database.dbc.attributes_rel
     for frame_id, element in attributes_rel.items():
         if "signal" in element:
@@ -1021,8 +1042,10 @@ def _dump_signal_mux_values(database: InternalDatabase) -> list[str]:
 
 def _dump_environment_variables(database: InternalDatabase) -> list[str]:
     """Dump environment variables (EV_ entries)."""
-    ev_lines: list[str] = []
+    if database.dbc is None:
+        return  []
 
+    ev_lines: list[str] = []
     for env in database.dbc.environment_variables.values():
         # Prepare values, using empty strings for None where appropriate
         env_type = env.env_type if env.env_type is not None else ''
@@ -1927,7 +1950,8 @@ def make_message_names_unique(database: InternalDatabase, shorten_long_names: bo
     for message in database.messages:
         long_name = message.name
         short_name = converter.long_to_short[long_name]
-        try_remove_attribute(message.dbc, 'SystemMessageLongSymbol')
+        if message.dbc is not None:
+            try_remove_attribute(message.dbc, 'SystemMessageLongSymbol')
 
         if (long_name == short_name) or not shorten_long_names:
             continue

--- a/src/cantools/database/can/internal_database.py
+++ b/src/cantools/database/can/internal_database.py
@@ -24,5 +24,5 @@ class InternalDatabase:
         self.nodes = nodes
         self.buses = buses
         self.version = version
-        self.dbc = dbc_specifics or DbcSpecifics()
+        self.dbc = dbc_specifics
         self.autosar = autosar_specifics

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -132,8 +132,8 @@ class Message:
         self._senders = senders or []
         self._send_type = send_type
         self._cycle_time = cycle_time
-        self._dbc = dbc_specifics or DbcSpecifics()
-        self._autosar = autosar_specifics or AutosarMessageSpecifics()
+        self._dbc = dbc_specifics
+        self._autosar = autosar_specifics
         self._bus_name = bus_name
         self._signal_groups = signal_groups
         self._codecs: Codec | None = None
@@ -455,7 +455,7 @@ class Message:
         self._cycle_time = value
 
     @property
-    def dbc(self) -> DbcSpecifics:
+    def dbc(self) -> DbcSpecifics | None:
         """An object containing dbc specific properties like e.g. attributes.
 
         """
@@ -463,11 +463,11 @@ class Message:
         return self._dbc
 
     @dbc.setter
-    def dbc(self, value: DbcSpecifics) -> None:
+    def dbc(self, value: DbcSpecifics | None) -> None:
         self._dbc = value
 
     @property
-    def autosar(self) -> AutosarMessageSpecifics:
+    def autosar(self) -> AutosarMessageSpecifics | None:
         """An object containing AUTOSAR specific properties
 
         e.g. auxiliary data required to implement CRCs, secure on-board
@@ -477,7 +477,7 @@ class Message:
         return self._autosar
 
     @autosar.setter
-    def autosar(self, value: AutosarMessageSpecifics) -> None:
+    def autosar(self, value: AutosarMessageSpecifics | None) -> None:
         self._autosar = value
 
     @property

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4423,7 +4423,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(db.nodes), 2)
         self.assertEqual(len(db.messages), 2)
         self.assertTrue(db.autosar is not None)
-        self.assertTrue(db.dbc is not None)
+        self.assertTrue(db.dbc is None)
         self.assertEqual(db.autosar.arxml_version, "3.2.3")
 
         node1 = db.nodes[0]
@@ -4446,7 +4446,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(mux_message.signals), 6)
         self.assertEqual(mux_message.comments, None)
         self.assertEqual(mux_message.bus_name, 'Network')
-        self.assertTrue(mux_message.dbc is not None)
+        self.assertTrue(mux_message.dbc is None)
         self.assertTrue(mux_message.autosar is not None)
         self.assertEqual(mux_message.autosar.pdu_paths, [
             '/Network/CanCluster/CAN/PDUs/Multiplexed',
@@ -4569,7 +4569,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(message_1.signals), 6)
         self.assertEqual(message_1.comments["EN"], 'The lonely frame description')
         self.assertEqual(message_1.bus_name, 'Network')
-        self.assertTrue(message_1.dbc is not None)
+        self.assertTrue(message_1.dbc is None)
         self.assertTrue(message_1.autosar is not None)
         self.assertEqual(message_1.autosar.pdu_paths, [ '/Network/CanCluster/CAN/PDUs/Status' ])
 
@@ -4705,7 +4705,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(db.nodes), 3)
         self.assertEqual(len(db.messages), 8)
         self.assertTrue(db.autosar is not None)
-        self.assertTrue(db.dbc is not None)
+        self.assertTrue(db.dbc is None)
         self.assertEqual(db.autosar.arxml_version, "4.0.0")
 
         node1 = db.nodes[0]
@@ -4735,7 +4735,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(mux_message.bus_name, 'Cluster0')
         self.assertEqual(mux_message.comments, None)
         self.assertEqual(mux_message.comment, None)
-        self.assertTrue(mux_message.dbc is not None)
+        self.assertTrue(mux_message.dbc is None)
         self.assertTrue(mux_message.autosar is not None)
         self.assertEqual(mux_message.autosar.pdu_paths, [
             '/MultiplexedIPdu/multiplexed_message',
@@ -4851,7 +4851,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
                              'DE': 'Kommentar eins',
                              'EN': 'Comment one'
                          })
-        self.assertTrue(message_1.dbc is not None)
+        self.assertTrue(message_1.dbc is None)
         self.assertTrue(message_1.autosar is not None)
         self.assertEqual(message_1.autosar.pdu_paths, [ '/ISignalIPdu/message1' ])
 
@@ -4976,7 +4976,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(message_2.signals), 3)
         self.assertEqual(message_2.comment, None)
         self.assertEqual(message_2.bus_name, 'Cluster0')
-        self.assertTrue(message_2.dbc is not None)
+        self.assertTrue(message_2.dbc is None)
         self.assertTrue(message_2.autosar is not None)
         self.assertEqual(message_2.autosar.pdu_paths, [ '/ISignalIPdu/message2' ])
 
@@ -5049,7 +5049,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(message_3.signals), 4)
         self.assertEqual(message_3.comment, None)
         self.assertEqual(message_3.bus_name, 'Cluster0')
-        self.assertTrue(message_3.dbc is not None)
+        self.assertTrue(message_3.dbc is None)
         self.assertTrue(message_3.autosar is not None)
         self.assertEqual(message_3.autosar.pdu_paths,
                          [
@@ -5143,7 +5143,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(message_4.signals), 3)
         self.assertEqual(message_4.comment, None)
         self.assertEqual(message_4.bus_name, 'Cluster0')
-        self.assertTrue(message_4.dbc is not None)
+        self.assertTrue(message_4.dbc is None)
         self.assertTrue(message_4.autosar is not None)
         self.assertEqual(message_4.autosar.pdu_paths, [ '/ISignalIPdu/message4' ])
 
@@ -5177,7 +5177,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(container_message._contained_messages), 5)
         header_ids = sorted([cm.header_id for cm in container_message._contained_messages])
         self.assertEqual(header_ids, [ 0x010203, 0x040506, 0x070809, 0x0a0b0c, 0x1d2e3f ])
-        self.assertTrue(container_message.dbc is not None)
+        self.assertTrue(container_message.dbc is None)
         self.assertTrue(container_message.autosar is not None)
         self.assertEqual(container_message.autosar.pdu_paths,
             [
@@ -5204,7 +5204,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(nm_message.signals), 1)
         self.assertEqual(nm_message.comment, None)
         self.assertEqual(nm_message.bus_name, 'Cluster0')
-        self.assertTrue(nm_message.dbc is not None)
+        self.assertTrue(nm_message.dbc is None)
         self.assertTrue(nm_message.autosar is not None)
 
         msg_without_pdu = db.messages[7]
@@ -5218,7 +5218,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(msg_without_pdu.signals), 0)
         self.assertEqual(msg_without_pdu.comment, None)
         self.assertEqual(msg_without_pdu.bus_name, 'Cluster0')
-        self.assertTrue(msg_without_pdu.dbc is not None)
+        self.assertTrue(msg_without_pdu.dbc is None)
         self.assertTrue(msg_without_pdu.autosar is not None)
 
     def test_system_arxml_traversal(self):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -58,8 +58,6 @@ ExampleMessage:
   Size: 8 bytes
   Is extended frame: False
   Is CAN-FD frame: False
-  Is network management frame: False
-  Is secured: False
   Signal tree:
 
     -- {root}
@@ -525,8 +523,6 @@ Message1:
   Size: 5 bytes
   Is extended frame: False
   Is CAN-FD frame: False
-  Is network management frame: False
-  Is secured: False
   Signal tree:
 
     -- {root}
@@ -559,8 +555,6 @@ Message2:
   Is extended frame: False
   Is CAN-FD frame: False
   Cycle time: 100 ms
-  Is network management frame: False
-  Is secured: False
   Signal tree:
 
     -- {root}
@@ -650,8 +644,6 @@ Message4:
   Size: 5 bytes
   Is extended frame: False
   Is CAN-FD frame: False
-  Is network management frame: False
-  Is secured: False
   Signal tree:
 
     -- {root}
@@ -694,8 +686,6 @@ Message3:
   Size: 8 bytes
   Is extended frame: True
   Is CAN-FD frame: False
-  Is network management frame: False
-  Is secured: False
   Signal tree:
 
     -- {root}


### PR DESCRIPTION
changing this to be an always present dummy object would constitute a major API change for which the juice is not worth the squeeze IMO.